### PR TITLE
Added current datetime to google_row

### DIFF
--- a/webform_to_gdocs.module
+++ b/webform_to_gdocs.module
@@ -96,6 +96,9 @@ function webform_to_gdocs_webform_submission_insert($node, $submission) {
 
     $google_row[$spreadsheet_column] = $insert_value;
   }
+  
+  $google_row['date'] = date('Y-m-d H:i:s');
+
   try {
     // Ensure we have a working access token.
     _webform_to_gdocs_google_drive_get_service();


### PR DESCRIPTION
I needed to store the timestamp of the webform submission.

I don't know if anyone else have the same requirement, or if it could be solved in a more elegant way. Perhaps it could be loaded from `$submission` instead of using `date()`.
